### PR TITLE
download fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG IMAGE=intersystemsdc/irishealth-community:2020.4.0.521.0-zpm
 ARG IMAGE=containers.intersystems.com/intersystems/irishealth-community:2020.1.408.0
+ARG IMAGE=intersystemsdc/irishealth-community:2020.4.0.547.0-zpm
 FROM $IMAGE
 # copy files
 COPY . /tmp/iris


### PR DESCRIPTION
````
Step 3/12 : FROM $IMAGE
ERROR: Service 'iris' failed to build : 
manifest for containers.intersystems.com/intersystems/irishealth-community:2020.1.408.0 not found: 
manifest unknown: The named manifest is not known to the registry.
````